### PR TITLE
updated 'image_registry_credential'

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -4,7 +4,7 @@
 
 formatter: "markdown document" # this is required
 
-version: "~> 0.17.0"
+version: "~> 0.18"
 
 header-from: "_header.md"
 footer-from: "_footer.md"

--- a/README.md
+++ b/README.md
@@ -193,10 +193,10 @@ Type:
 
 ```hcl
 map(object({
-    user_assigned_identity_id = string
+    user_assigned_identity_id = optional(string)
     server                    = string
-    username                  = string
-    password                  = string
+    username                  = optional(string)
+    password                  = optional(string)
   }))
 ```
 

--- a/examples/.terraform-docs.yml
+++ b/examples/.terraform-docs.yml
@@ -4,7 +4,7 @@
 
 formatter: "markdown document" # this is required
 
-version: "~> 0.17.0"
+version: "~> 0.18"
 
 header-from: "_header.md"
 footer-from: "_footer.md"

--- a/main.telemetry.tf
+++ b/main.telemetry.tf
@@ -3,7 +3,8 @@ data "azurerm_client_config" "telemetry" {
 }
 
 data "modtm_module_source" "telemetry" {
-  count       = var.enable_telemetry ? 1 : 0
+  count = var.enable_telemetry ? 1 : 0
+
   module_path = path.module
 }
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -6,13 +6,13 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.71"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.5"
-    }
     modtm = {
       source  = "Azure/modtm"
       version = "~> 0.3"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -106,10 +106,10 @@ variable "exposed_ports" {
 
 variable "image_registry_credential" {
   type = map(object({
-    user_assigned_identity_id = string
+    user_assigned_identity_id = optional(string)
     server                    = string
-    username                  = string
-    password                  = string
+    username                  = optional(string)
+    password                  = optional(string)
   }))
   default     = {}
   description = "The credentials for the image registry."


### PR DESCRIPTION
## Description
Closes #29 

updated `image_registry_credential` to allow `username`/`password` or `user_assigned_identity_id`

updates terraform-docs version constraint

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ X ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ X ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ X ] Update to documentation

# Checklist

- [ X ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ X ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
